### PR TITLE
Add npm support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "main": "dist/index.js",
   "type": "commonjs",
   "repository": "github:prelude-so/node-sdk",
+  "homepage": "https://docs.prelude.so",
+  "bugs": {
+    "url": "https://github.com/prelude-so/node-sdk/issues"
+  },
   "license": "Apache-2.0",
   "packageManager": "yarn@1.22.22",
   "files": [


### PR DESCRIPTION
## Summary
- add homepage metadata pointing to the public Prelude API docs
- add bugs metadata pointing to the repository issue tracker

## Verification
- node manifest assertion
- git diff --check
- npm pack --dry-run --json --ignore-scripts